### PR TITLE
Makefile: set install permission modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ all: $(TARGETS)
 
 install: $(TARGETS)
 	install -d $(MANDIR)
-	install man/dnf.kpatch.8.gz $(MANDIR)
+	install -m 644 man/dnf.kpatch.8.gz $(MANDIR)
 	install -d $(CONFDIR)
-	install conf/kpatch.conf $(CONFDIR)
+	install -m 644 conf/kpatch.conf $(CONFDIR)
 	install -d $(DNFPLUGINDIR)
-	install kpatch.py $(DNFPLUGINDIR)
+	install -m 644 kpatch.py $(DNFPLUGINDIR)
 
 %.gz: %
 	gzip --keep $^


### PR DESCRIPTION
By default, the install command will apply rwxr-xr-x permissions (how
intuitive).  Give the command expected file modes to avoid rpmbuild
complaints like this:

  *** WARNING: ./usr/lib/python3.9/site-packages/dnf-plugins/kpatch.py is executable but has no shebang, removing executable bit
  *** WARNING: ./etc/dnf/plugins/kpatch.conf is executable but has no shebang, removing executable bit

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>