### PR TITLE
Status query

### DIFF
--- a/kpatch.py
+++ b/kpatch.py
@@ -80,10 +80,16 @@ class KpatchCmd(dnf.cli.Command):
 
     def configure(self):
         demands = self.cli.demands
-        demands.resolving = True
+
         demands.root_user = True
-        demands.sack_activation = True
-        demands.available_repos = True
+        if self.opts.action == "auto":
+            demands.resolving = True
+            demands.sack_activation = True
+            demands.available_repos = True
+        else:
+            demands.resolving = False
+            demands.sack_activation = False
+            demands.available_repos = False
 
 
     def _install_missing_kpp_pkgs(self):

--- a/man/dnf.kpatch.8
+++ b/man/dnf.kpatch.8
@@ -5,7 +5,7 @@ dnf\-kpatch \- kpatch patch module installation plugin
 .SH SYNOPSIS
 .SY dnf
 .B kpatch
-.I install\-mode
+.I operation
 
 .SH DESCRIPTION
 \fBdnf\-kpatch\fR is a \fBdnf\fR(8) plugin providing automated installation of
@@ -15,7 +15,7 @@ targeting the same kernel version.
 
 .SH OPTIONS
 .TP
-.B install\-mode
+.B operation
 .RS
 .TP 8
 .B auto
@@ -24,6 +24,9 @@ automatic kpatch\-patch installation for future kernel installations.
 .TP
 .B manual
 Disables automatic installation of kpatch-patch packages.
+.TP
+.B status
+Queries the current installation setting of \fBdnf\-kpatch\fR.
 .RE
 
 .SH SEE ALSO


### PR DESCRIPTION
It was brought up that it might be useful to have a way to query the current setting of dnf-kpatch.

This pull request disables unnecessary dnf demands from the plugin since dnf feature are not necessary to interact with the configuration file. And then add the subcommand to query the installation setting.