### PR TITLE
kpatch: Filtering of kpatch supported kernels.

### DIFF
--- a/conf/kpatch.conf
+++ b/conf/kpatch.conf
@@ -1,2 +1,3 @@
 [main]
 autoupdate=False
+autofilter=False

--- a/kpatch.py
+++ b/kpatch.py
@@ -27,10 +27,12 @@ import re
 
 from dnfpluginscore import _, logger
 
+import dnf
 import dnf.callback
 import dnf.cli
 import dnf.exceptions
 import dnf.transaction
+import hawkey
 
 KPATCH_PLUGIN_NAME = "kpatch"
 KPATCH_UPDATE_OPT = "autoupdate"
@@ -211,6 +213,10 @@ class KpatchPlugin(dnf.Plugin):
 
     name = KPATCH_PLUGIN_NAME
 
+    # list of package names to filter based on kpatch support
+    kernel_pkg_names = ['kernel', 'kernel-core', 'kernel-modules',
+                        'kernel-modules-core', 'kernel-modules-extra']
+    kpatch_requirement = ['kernel', 'kernel-uname-r']
 
     def __init__(self, base, cli):
         super(KpatchPlugin, self).__init__(base, cli)
@@ -240,6 +246,48 @@ class KpatchPlugin(dnf.Plugin):
         self.base.resolve(self.cli.demands.allow_erasing)
         self._commiting = False
 
+
+    def sack(self):
+        if not self._autofilter:
+            return
+
+        print('Please note, kpatch filter is enabled, only kpatch supported kernels are shown.')
+
+        # This query gradually accumulates all kernel packages that should be
+        # offered to the user (kernels for which exists kpatch-patch-* package
+        # that requires it). Start with empty query.
+        kernels_keep = self.base.sack.query().filterm(empty=True)
+
+        # pre-filter all available versions of the kernel* packages
+        kernels_query = self.base.sack.query(flags=hawkey.IGNORE_EXCLUDES)
+        kernels_query.filterm(name=self.kernel_pkg_names)
+        # any installed kernel version should not be excluded
+        kernels_query = kernels_query.available()
+
+        # Add to the kernels_keep query all kernel-core package versions that are
+        # required by any of kpatch-patch-* packages.
+        kpatch_query = self.base.sack.query(flags=hawkey.IGNORE_EXCLUDES)
+        kpatch_query.filterm(name__glob="kpatch-patch-*")
+        for kpatch_pkg in kpatch_query:
+            for require in kpatch_pkg.requires:
+                require_parsed = str(require).split(' ')
+                if len(require_parsed) < 3:
+                    continue
+                if require_parsed[0] in self.kpatch_requirement:
+                    # get kernel-core package providing "kernel-uname-r = <kpatch_pkg.evra>"
+                    kernel_core = kernels_query.filter(provides=require)
+                    kernel_evr = None
+                    for kernel_core_pkg in kernel_core:
+                        # assume that all such packages have the same evr
+                        kernel_evr = kernel_core_pkg.evr
+                        break
+                    if kernel_evr is not None:
+                        kernels_keep = kernels_keep.union(kernels_query.filter(evr=kernel_evr))
+                    # assume the is only one kernel-uname-r requirement
+                    break
+
+        # exclude all kernel-core packages that are not in kernels_keep query
+        self.base.sack.add_excludes(kernels_query.difference(kernels_keep))
 
     def resolved(self):
         # Calling self.base.resolve() will run this callback again

--- a/man/dnf.kpatch.8
+++ b/man/dnf.kpatch.8
@@ -18,12 +18,20 @@ targeting the same kernel version.
 .B operation
 .RS
 .TP 8
-.B auto
+.B auto\-update, auto
 Installs missing kpatch\-patch packages for installed kernels and enables
-automatic kpatch\-patch installation for future kernel installations.
+their automatic installation for future kernel updates.
 .TP
-.B manual
-Disables automatic installation of kpatch-patch packages.
+.B manual\-update, manual
+Disables automatic installation of kpatch\-patch packages.
+.TP
+.B auto\-filter
+Shows only the kernel packages in the DNF database that have
+a kpatch\-patch counterpart.
+.TP
+.B no\-filter
+Shows all available kernel packages, including those that do not have
+a kpatch\-patch counterpart.
 .TP
 .B install
 Installs missing kpatch\-patch packages for installed kernels.
@@ -53,4 +61,4 @@ Julien Thierry
 .SH COPYRIGHT
 Copyright (\[co]) 2020 Julien Thierry <jthierry@redhat.com>
 
-2020, Red Hat, Licensed under GPLv2+
+2024, 2020, Red Hat, Licensed under GPLv2+


### PR DESCRIPTION
Extend the current kpatch DNF plugin to filter packages supported by kpatch.

* Rename existing DNF subcommands to be less confusing
* Add new subcommands to enable filtering
* Formal changes to python code
* Update of the man page to reflect the code changes

V2 Incorporate changes from feedback:
* Fix typo in commit message
* Replace smart quotes with boring ASCII ones
* Add "Based-on-code-by" to individual patches
* Remove "the" article from man pages where it was previously not present

Based-on-code-by: Marek Blaha <mblaha@redhat.com>
Based-on-code-by: Joe Lawrence <jolawren@redhat.com>
Signed-off-by: Radomir Vrbovsky <rvrbovsk@redhat.com>